### PR TITLE
Update `ss58-registry` to 1.43.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8184,9 +8184,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.41.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc443bad666016e012538782d9e3006213a7db43e9fb1dda91657dc06a6fa08"
+checksum = "5e6915280e2d0db8911e5032a5c275571af6bdded2916abd691a659be25d3439"
 dependencies = [
  "Inflector",
  "num-format",


### PR DESCRIPTION
The new version has `metaquity_network` in the registry file.